### PR TITLE
Fix missing 'notice_types_enabled' argument in School constructor

### DIFF
--- a/src/smhw_api/api.py
+++ b/src/smhw_api/api.py
@@ -946,7 +946,7 @@ class Client:
         """
         if requestDate is None:
             now = datetime.datetime.now()
-        requestDate = now - datetime.timedelta(days=now.weekday())
+            requestDate = now - datetime.timedelta(days=now.weekday())
 
         params = {
             "requestDate": requestDate.strftime("%Y-%m-%d"),

--- a/src/smhw_api/api.py
+++ b/src/smhw_api/api.py
@@ -289,7 +289,7 @@ class Client:
         r = self._get_request(f"/users/{user_id}")
         if r.status_code == 404:
             raise exceptions.InvalidUser(user_id)
-        return objects.Create.instantiate(objects.User, r["user"])
+        return objects.Create.instantiate(objects.User, r.json()["user"])
 
     def get_current_student(
         self,

--- a/src/smhw_api/objects.py
+++ b/src/smhw_api/objects.py
@@ -709,7 +709,6 @@ class TaskSearchResult:
     student_name_sims_format: str
     grade: Any
     student_avatar: str
-    grading_comment: Any
     completed: bool
     overdue: bool
     marked: bool
@@ -726,6 +725,7 @@ class TaskSearchResult:
     quiz_task_id: int = None
     class_test_task_id: int = None
     classwork_task_id: int = None
+    grading_comment: Any = field(default_factory=lambda: None)
 
     def __post_init__(self):
         self.created_at = convert_datetime(self.created_at)

--- a/src/smhw_api/objects.py
+++ b/src/smhw_api/objects.py
@@ -862,7 +862,7 @@ class TimetableDay:
     date: datetime
     lessons: list[TimetableLesson]
     registration_group: str
-    detentions: list[Any]
+    detentions: list[Any] = field(default_factory=list)
 
     def __post_init__(self):
         self.date = datetime.strptime(self.date, "%Y-%m-%d")

--- a/src/smhw_api/objects.py
+++ b/src/smhw_api/objects.py
@@ -390,7 +390,6 @@ class School:
     is_discussion_enabled: bool
     share_classroom_enabled: bool
     share_task_to_teams_enabled: bool
-    notice_types_enabled: bool
     domains_for_email_import: str
     domain = str  # domains_for_email_import
     school_private_info_id: int
@@ -445,6 +444,7 @@ class School:
     pulse_promo: bool
     announcement_category_ids: list[int]
     subjects: list[Subject]
+    notice_types_enabled: bool = field(default_factory=bool)
 
     def __post_init__(self):
         self.created_at = convert_datetime(self.created_at)


### PR DESCRIPTION
Added a default value for the 'notice_types_enabled' parameter in the School class using field(default_factory=bool).
This should fix the following error: `TypeError: School.__init__() missing 1 required positional argument: 'notice_types_enabled'`